### PR TITLE
feat: フレーズ詳細ページの作成

### DIFF
--- a/components/molecules/PhraseCard.tsx
+++ b/components/molecules/PhraseCard.tsx
@@ -1,22 +1,19 @@
-import CardCase from '../atoms/CardCase'
 import { UserBar } from './UserBar'
 import { PhraseTextLine } from './PhraseTextLine'
 import { Phrase } from '../../types/types'
 
 const PhraseCard: React.VFC<{ phrase: Phrase }> = ({ phrase }) => {
   return (
-    <CardCase hover={true}>
-      <div className="flex flex-col w-full space-y-2">
-        <PhraseTextLine text={phrase.text} languageCode={phrase.textLanguage} />
+    <div className="flex flex-col w-full space-y-2">
+      <PhraseTextLine text={phrase.text} languageCode={phrase.textLanguage} />
 
-        <PhraseTextLine
-          text={phrase.translatedWord}
-          languageCode={phrase.translatedWordLanguage}
-        />
+      <PhraseTextLine
+        text={phrase.translatedWord}
+        languageCode={phrase.translatedWordLanguage}
+      />
 
-        <UserBar username={phrase.username} updatedAt={phrase.updatedAt} />
-      </div>
-    </CardCase>
+      <UserBar username={phrase.username} updatedAt={phrase.updatedAt} />
+    </div>
   )
 }
 

--- a/components/organisms/PhraseCardList.tsx
+++ b/components/organisms/PhraseCardList.tsx
@@ -1,5 +1,7 @@
 import { Phrases } from '../../types/types'
 import PhraseCard from '../molecules/PhraseCard'
+import CardCase from '../atoms/CardCase'
+import Link from 'next/link'
 
 const PhraseCardList: React.VFC<Phrases> = ({ phrases }) => {
   return (
@@ -7,7 +9,13 @@ const PhraseCardList: React.VFC<Phrases> = ({ phrases }) => {
       {phrases &&
         phrases.map((phrase) => (
           <li key={phrase.id}>
-            <PhraseCard phrase={phrase} />
+            <Link href={`/phrases/${phrase.id}`}>
+              <a>
+                <CardCase hover={true}>
+                  <PhraseCard phrase={phrase} />
+                </CardCase>
+              </a>
+            </Link>
           </li>
         ))}
     </ul>

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,7 +1,26 @@
-import fetch, { Response } from 'node-fetch'
+import fetch from 'node-fetch'
 import { Phrase } from '../types/types'
 
 export const getAllPhrasesData = async (): Promise<Phrase[]> => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_RESTAPI_URL}/api/phrase/`)
   return (await res.json()) as Phrase[]
+}
+
+export const getAllPhraseIds = async () => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_RESTAPI_URL}/api/phrase/`)
+  const phrases = (await res.json()) as Phrase[]
+  return phrases.map((phrase) => {
+    return {
+      params: {
+        id: String(phrase.id),
+      },
+    }
+  })
+}
+
+export const getPhraseData = async (id: string) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}/api/phrase/${id}`
+  )
+  return (await res.json()) as Phrase
 }

--- a/pages/phrases/[id].tsx
+++ b/pages/phrases/[id].tsx
@@ -1,0 +1,38 @@
+import { GetStaticProps, GetStaticPaths } from 'next'
+import { getAllPhraseIds, getPhraseData } from '../../lib/fetch'
+import Layout from '../../components/templates/Layout'
+import { Phrase } from '../../types/types'
+import PhraseCard from '../../components/molecules/PhraseCard'
+import CardCase from '../../components/atoms/CardCase'
+import { useRouter } from 'next/router'
+
+const PhraseDetail: React.VFC<{ phrase: Phrase }> = ({ phrase }) => {
+  const router = useRouter()
+  if (router.isFallback || !phrase) {
+    return <div>Loading...</div>
+  }
+  return (
+    <Layout title="phrase detail">
+      <CardCase hover={false}>
+        <PhraseCard phrase={phrase} />
+      </CardCase>
+    </Layout>
+  )
+}
+export default PhraseDetail
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths = await getAllPhraseIds()
+  return {
+    paths,
+    fallback: true,
+  }
+}
+
+export const getStaticProps: GetStaticProps = async (ctx) => {
+  const phrase = await getPhraseData(ctx.params.id as string)
+  return {
+    props: { phrase },
+    revalidate: 1,
+  }
+}


### PR DESCRIPTION
## Issue 番号

#2 の対応

## 概要

- Phrase詳細ページの作成

## 参考記事など

- https://qiita.com/enuii3/items/2cb2fa94f1b13843973a
- router.isFallbackを精査にかけることで、fallback: trueの状態(404ページを表示しない)でデプロイができた

## スクリーンショット

<img width="457" alt="スクリーンショット 2022-05-31 14 51 38" src="https://user-images.githubusercontent.com/46844364/171102092-a7a92aaf-5324-4d3e-951e-0d2771e3c8e2.png">


## チェックリスト

- [x] VSCode が警告やエラーを出さないこと