### PR TITLE
feat: コメント件数といいね件数の表示とmoleculesディレクトリからorganismsディレクトリに移行

### DIFF
--- a/components/atoms/CommentIcon.tsx
+++ b/components/atoms/CommentIcon.tsx
@@ -1,0 +1,23 @@
+const CommentIcon: React.VFC<{ commentCount: number }> = ({ commentCount }) => {
+  return (
+    <div className="flex justify-center items-center text-pink-500 space-x-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+        />
+      </svg>
+      <p>{commentCount}</p>
+    </div>
+  )
+}
+
+export default CommentIcon

--- a/components/atoms/HeartIcon.tsx
+++ b/components/atoms/HeartIcon.tsx
@@ -1,0 +1,23 @@
+const HeartIcon: React.VFC = () => {
+  return (
+    <div className="flex justrify-center items-center text-pink-500 space-x-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+        />
+      </svg>
+      <p>0</p>
+    </div>
+  )
+}
+
+export default HeartIcon

--- a/components/atoms/WhiteCardCase.tsx
+++ b/components/atoms/WhiteCardCase.tsx
@@ -1,0 +1,5 @@
+const WhiteCardCase = ({ children }) => {
+  return <div className="w-full bg-white rounded-md p-2">{children}</div>
+}
+
+export default WhiteCardCase

--- a/components/molecules/PhraseCardIconBar.tsx
+++ b/components/molecules/PhraseCardIconBar.tsx
@@ -1,0 +1,15 @@
+import CommentIcon from '../atoms/CommentIcon'
+import HeartIcon from '../atoms/HeartIcon'
+
+const PhraseCardIconBar: React.VFC<{ commentCount: number }> = ({
+  commentCount,
+}) => {
+  return (
+    <div className="flex justify-around items-center">
+      <CommentIcon commentCount={commentCount} />
+      <HeartIcon />
+    </div>
+  )
+}
+
+export default PhraseCardIconBar

--- a/components/organisms/PhraseCard.tsx
+++ b/components/organisms/PhraseCard.tsx
@@ -1,12 +1,22 @@
-import UserBar from './UserBar'
-import LanguageTextLine from './LanguageTextLine'
+import UserBar from '../molecules/UserBar'
+import LanguageTextLine from '../molecules/LanguageTextLine'
 import { Phrase, Comment } from '../../types/types'
-import CommentCard from './CommentCard'
+import WhiteCardCase from '../atoms/WhiteCardCase'
+import PhraseCardIconBar from '../molecules/PhraseCardIconBar'
+import CommentCard from '../molecules/CommentCard'
 
 const PhraseCard: React.VFC<{ phrase: Phrase; comments?: Comment[] }> = ({
   phrase,
   comments,
 }) => {
+  const countComment = (commentCount: string[]): number => {
+    try {
+      return commentCount.length
+    } catch (error) {
+      return 0
+    }
+  }
+
   return (
     <div className="flex flex-col w-full space-y-2">
       <LanguageTextLine text={phrase.text} languageCode={phrase.textLanguage} />
@@ -15,8 +25,10 @@ const PhraseCard: React.VFC<{ phrase: Phrase; comments?: Comment[] }> = ({
         text={phrase.translatedWord}
         languageCode={phrase.translatedWordLanguage}
       />
-
-      <UserBar username={phrase.username} updatedAt={phrase.updatedAt} />
+      <WhiteCardCase>
+        <UserBar username={phrase.username} updatedAt={phrase.updatedAt} />
+      </WhiteCardCase>
+      <PhraseCardIconBar commentCount={countComment(phrase.comments)} />
       <ul className="w-full space-y-2">
         {comments &&
           comments.map((comment) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import Layout from '../components/templates/Layout'
 import { GetStaticProps } from 'next'
 import { getAllPhrasesData } from '../lib/fetch'
 import { Phrases } from '../types/types'
-import PhraseCard from '../components/molecules/PhraseCard'
+import PhraseCard from '../components/organisms/PhraseCard'
 import PhraseCardCase from '../components/atoms/PhraseCardCase'
 import Link from 'next/link'
 

--- a/pages/phrases/[id].tsx
+++ b/pages/phrases/[id].tsx
@@ -1,10 +1,10 @@
+import { useRouter } from 'next/router'
 import { GetStaticProps, GetStaticPaths } from 'next'
 import { getAllPhraseIds, getPhraseData, getCommentData } from '../../lib/fetch'
 import Layout from '../../components/templates/Layout'
 import { Phrase, Comment } from '../../types/types'
-import PhraseCard from '../../components/molecules/PhraseCard'
+import PhraseCard from '../../components/organisms/PhraseCard'
 import PhraseCardCase from '../../components/atoms/PhraseCardCase'
-import { useRouter } from 'next/router'
 
 const PhraseDetail: React.VFC<{ phrase: Phrase; comments: Comment[] }> = ({
   phrase,

--- a/types/types.ts
+++ b/types/types.ts
@@ -43,6 +43,7 @@ export type Phrase = {
   translatedWord: string
   translatedWordLanguage: LanguageCode
   username: string
+  comments: string[]
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## 概要

- WhiteCardCaseコンポーネントの作成
- PhraseCardコンポーネントをcomponents/moleculesディレクトリからcomponents/organismsディレクトリに移行


## スクリーンショット
一覧画面
<img width="356" alt="スクリーンショット 2022-06-17 12 47 12" src="https://user-images.githubusercontent.com/46844364/174220891-a520890c-a595-4d17-be93-1fd0059863dd.png">


詳細画面
<img width="357" alt="スクリーンショット 2022-06-17 12 47 30" src="https://user-images.githubusercontent.com/46844364/174220940-6a5c0c34-e40a-4d20-8e16-3f752d55fb31.png">

## チェックリスト

- [x] VSCode が警告やエラーを出さないこと
- [x] コメント件数が一覧画面、詳細画面ともに表示されていること
