### PR TITLE
fix: なんで書いたか分からないので一旦コメントアウト

### DIFF
--- a/components/organisms/PhraseCard.tsx
+++ b/components/organisms/PhraseCard.tsx
@@ -20,13 +20,14 @@ const PhraseCard: React.VFC<{ phrase: Phrase; comments?: Comment[] }> = ({
     }
   }
 
-  const routeDetailPhrase = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    e.stopPropagation()
-    router.push(`/phrases/${phrase.id}`)
-  }
+  // const routeDetailPhrase = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+  //   e.stopPropagation()
+  //   router.push(`/phrases/${phrase.id}`)
+  // }
 
   return (
-    <div className="flex flex-col w-full space-y-2" onClick={routeDetailPhrase}>
+    // <div className="flex flex-col w-full space-y-2" onClick={routeDetailPhrase}>
+    <div className="flex flex-col w-full space-y-2">
       <LanguageTextLine text={phrase.text} languageCode={phrase.textLanguage} />
 
       <LanguageTextLine


### PR DESCRIPTION
## 概要

- コメントをするためにログインしてもらう動線を辿ったときに、フレーズ詳細ページに戻ってしまうバグの修正(自分でもなぜ書いたのか分からないが、書く場所、やりたいことが間違っているだけの可能性があるので、一旦コメントアウト)

## チェックリスト

- [x] VSCode が警告やエラーを出さないこと
- [x] local環境では正常な動作をしていること